### PR TITLE
Fix #14 (node 10.x) & Fix #16 (eliminate stage Stage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ aws cloudformation deploy \
 
 *Note*: Ensure that NewDomain is prefixed with either `http://` or `https://` or you will get a chain of redirects to a never-ending path on the source domain. It will be amusing but will not meet your goal.
 
+*Note*: This redirector has a special feature where if you specify a query parameter in the NewDomain URL (e.g. `https://www.example.com/some/path?foo=bar") it will disregard the path and any query parameters passed in by the user and will redirect strictly to the NewDomain URL.
+
 ### Parameters
 Parameters | Type | Description
 ---|:---:|---

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ aws cloudformation deploy \
 
 *Note*: Ensure that NewDomain is prefixed with either `http://` or `https://` or you will get a chain of redirects to a never-ending path on the source domain. It will be amusing but will not meet your goal.
 
-*Note*: This redirector has a special feature where if you specify a query parameter in the NewDomain URL (e.g. `https://www.example.com/some/path?foo=bar") it will disregard the path and any query parameters passed in by the user and will redirect strictly to the NewDomain URL.
+*Note*: This redirector has a special feature where if you specify either a query parameter or a non-slash-terminated string in the NewDomain URL (e.g. ``https://www.example.com/snafu` or `https://www.example.com/some/path?foo=bar") it will disregard the path and any query parameters passed in by the user and will redirect strictly to the NewDomain URL.
 
 ### Parameters
 Parameters | Type | Description

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ aws cloudformation delete-stack --stack-name Redirector
 
 In order to fully configure a target domain for redirection, first establish a `Redirector` API Gateway through the CloudFormation Stack as described above. Then add a [Custom Domain Mapping through the AWS Console](https://console.aws.amazon.com/apigateway/home#/custom-domain-names). You can add a Custom Domain Name through the console, give it a DNS name, tell it to use an _Edge Optimized_ endpoint configuration, and give it a valid ACM certificate for the domain you are targeting. This can be a wildcard certificate, which might make things simpler for you if you are configuring multiple domains. Then Edit the custom domain name and do an _Add mapping_ operation to add a Base Path Mapping to map `/` to the `Redirector` Prod stage.
 
+Once this is configured, look for the _Target Domain Name_ under the Custom Domain Name / Endpoint Configuration in the console and chnage that to the DNS name you want to redirect _from_.
+
+
 # Caveat:
-Since we are using AWS SAM, we are going to run into [bug #191](https://github.com/awslabs/serverless-application-model/issues/191). If you look at the Stages in your API Gateway, you're going to see a stage named `Stage`. Hopefully this bug is fixed soon.
+The first version of this software had the same issue as SAM [bug #191](https://github.com/awslabs/serverless-application-model/issues/191). If you look at the Stages in your API Gateway, you may find a stage named `Stage`. As of 2019-11-15 this issue is resolved and new deployments of `lambda-redirector` should not have a `Stage` stage defined.
 
 # Contributing:
 See: http://www.contribution-guide.org/

--- a/app_spec.yml
+++ b/app_spec.yml
@@ -1,6 +1,9 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
+Globals:
+  Api:
+    OpenApiVersion: '3.0.2'
 Parameters:
   HTTPResponse:
     Type: Number

--- a/app_spec.yml
+++ b/app_spec.yml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       Description: "Handles GET requests."
       Handler: get.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: ./lambda
       Environment:
         Variables:

--- a/app_spec.yml
+++ b/app_spec.yml
@@ -58,3 +58,15 @@ Resources:
           Properties:
             Path: /
             Method: any
+Outputs:
+    apiGatewayConsoleDashboardUrl:
+        Value: !Sub " https://console.aws.amazon.com/apigateway/home?region=${AWS::Region}#/apis/${ServerlessRestApi}/dashboard"
+
+    redirectorInvokeUrl:
+        Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/"
+
+    anyFunctionArn:
+        Value: !GetAtt "AnyFunction.Arn"
+    getFunctionArn:
+        Value: !GetAtt "GetFunction.Arn"
+    

--- a/app_spec.yml
+++ b/app_spec.yml
@@ -41,7 +41,7 @@ Resources:
     Properties:
       Description: "Handles everything except GET requests."
       Handler: any.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: ./lambda
       Environment:
         Variables:

--- a/lambda/lib/helper.js
+++ b/lambda/lib/helper.js
@@ -30,11 +30,20 @@ module.exports.assembleRequest = function (path, query) {
 /**
  * Assemble the response to send to API Gateway.
  * 
+ * NOTE: If the new domain includes a query string, discard the request URI and
+ * just use the explicit domain given.
+ *
  * @param  {string} requestUri The path and the query joined using `?`.
  * @return {json}              The response sent to API Gateway via the Lambda proxy integration.
  *                             See: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
  */
 module.exports.assembleResponse = function (requestUri) {
+    var location;
+    if (process.env.NEW_DOMAIN.includes("?")) {
+        location = process.env.NEW_DOMAIN;
+    } else {
+        location = process.env.NEW_DOMAIN + requestUri;
+    }
     return {
         statusCode: process.env.HTTP_RESPONSE,
         headers: {

--- a/lambda/lib/helper.js
+++ b/lambda/lib/helper.js
@@ -39,7 +39,7 @@ module.exports.assembleRequest = function (path, query) {
  */
 module.exports.assembleResponse = function (requestUri) {
     var location;
-    if (process.env.NEW_DOMAIN.includes("?")) {
+    if (process.env.NEW_DOMAIN.includes("?") || ! process.env.NEW_DOMAIN.endsWith("/") {
         location = process.env.NEW_DOMAIN;
     } else {
         location = process.env.NEW_DOMAIN + requestUri;

--- a/lambda/lib/helper.js
+++ b/lambda/lib/helper.js
@@ -39,7 +39,7 @@ module.exports.assembleRequest = function (path, query) {
  */
 module.exports.assembleResponse = function (requestUri) {
     var location;
-    if (process.env.NEW_DOMAIN.includes("?") || ! process.env.NEW_DOMAIN.endsWith("/") {
+    if (process.env.NEW_DOMAIN.includes("?") || ! process.env.NEW_DOMAIN.endsWith("/")) {
         location = process.env.NEW_DOMAIN;
     } else {
         location = process.env.NEW_DOMAIN + requestUri;
@@ -47,7 +47,7 @@ module.exports.assembleResponse = function (requestUri) {
     return {
         statusCode: process.env.HTTP_RESPONSE,
         headers: {
-            "Location": process.env.NEW_DOMAIN + requestUri
+            "Location": location
         },
         body: null
     }


### PR DESCRIPTION
Fixes #16 
Fixes #14

Also adds a new feature where if your URL for NewDomain does not terminate with a `/` or has a query parameter in it, it will always redirect straight to NewDomain and it will discard user path and query parameters passed in.